### PR TITLE
Fix divide by zero panic

### DIFF
--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -72,6 +72,9 @@ func evalInfixExpression(il *parser.InfixExpression) Object {
 			Value: l * r,
 		}
 	case "/":
+		if r == 0 {
+			panic("0除算が発生しました")
+		}
 		return &Integer{
 			Value: l / r,
 		}

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -79,3 +79,15 @@ func TestEval(t *testing.T) {
 		})
 	}
 }
+
+func TestEval_DivideByZero(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("ゼロによる除算でpanicが発生しませんでした")
+		}
+	}()
+
+	l := lexer.New("1/0")
+	p := parser.New(l)
+	Eval(p.ParseProgram())
+}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -73,11 +73,11 @@ func New(l *lexer.Lexer) Parser {
 
 func (p *RecursiveDescentParser) ParseProgram() *Program {
 	return &Program{
-		Expression: p.parseAddtion(),
+		Expression: p.parseAddition(),
 	}
 }
 
-func (p *RecursiveDescentParser) parseAddtion() Expression {
+func (p *RecursiveDescentParser) parseAddition() Expression {
 	left := p.parseMultiplication()
 	for p.currentToken.Type == lexer.PLUS || p.currentToken.Type == lexer.MINUS {
 		operator := p.currentToken.Literal
@@ -128,7 +128,7 @@ func (p *RecursiveDescentParser) getIntegerLiteralAsExpression() Expression {
 		}
 	case lexer.LPAREN:
 		p.nextToken()
-		expr := p.parseAddtion()
+		expr := p.parseAddition()
 		if p.currentToken.Type != lexer.RPAREN {
 			panic("右括弧が見つかりません。")
 		}


### PR DESCRIPTION
## Summary
- check for divide by zero in the evaluator
- add test to ensure a panic occurs on zero division
- fix misspelled function name `parseAddition`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68416c0508c4832c967a296d093f5b5f